### PR TITLE
fix block_size fix for GDN to xpu update_block_size_for_backend

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -218,6 +218,57 @@ class XPUPlatform(Platform):
         os.environ["UCX_MEMTYPE_CACHE"] = "n"
 
     @classmethod
+    def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
+        super().update_block_size_for_backend(vllm_config)
+        from vllm.config.vllm import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention_layer_base import (
+            AttentionLayerBase,
+        )
+        from vllm.utils.math_utils import cdiv
+
+        cache_config = vllm_config.cache_config
+        # special fix for GDN since kernel only support block size of 64
+        attn_layers = get_layers_from_vllm_config(
+            vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+
+        kernel_block_size = None
+        for layer in attn_layers.values():
+            b = layer.get_attn_backend()
+            if b.get_name() == "GDN_ATTN":
+                kernel_block_size = 64
+                break
+
+        if kernel_block_size is None:
+            return
+        new_block_size = (
+            cdiv(cache_config.block_size, kernel_block_size) * kernel_block_size
+        )
+        if new_block_size == cache_config.block_size:
+            return
+
+        if cache_config.mamba_cache_mode == "align":
+            cache_config.mamba_block_size = new_block_size
+        original_mamba_page_size_padded = cache_config.mamba_page_size_padded
+        if cache_config.mamba_page_size_padded is not None:
+            attn_page_size_1_token = (
+                cache_config.mamba_page_size_padded // cache_config.block_size
+            )
+            cache_config.mamba_page_size_padded = (
+                new_block_size * attn_page_size_1_token
+            )
+        cache_config.block_size = new_block_size
+        logger.info(
+            "[XPU]Setting attention block size to %d tokens to ensure multiple of %d, "
+            "set mamba_page_size_padded to %d bytes accordingly, before was %d bytes.",
+            new_block_size,
+            kernel_block_size,
+            cache_config.mamba_page_size_padded,
+            original_mamba_page_size_padded,
+        )
+
+    @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
         return True
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -275,12 +275,6 @@ class TritonAttentionBackend(AttentionBackend):
         return [MultipleOf(16)]
 
     @classmethod
-    def get_preferred_block_size(cls, default_block_size: int) -> int:
-        if current_platform.is_xpu():
-            return max(default_block_size, 64)
-        return super().get_preferred_block_size(default_block_size)
-
-    @classmethod
     def supports_block_size(cls, block_size: int | None) -> bool:
         if block_size is None:
             return True


### PR DESCRIPTION
Original, this branch suggested to fix `triton_attn` with `block_size = 64` for XPU. Which will impact any triton_attention use case. 
This PR suggested to update in xpu `update_block_size_for_backend` since the `block_size=64` only needed by `GDN` (xpu version) and limitation might be removed in future. 

```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/basic/offline_inference/generate.py --model Qwen/Qwen3.5-9B  --enforce-eager  --attention-backend=TRITON_ATTN --max-model-len 4096 --temperature 0
```
<img width="800" height="231" alt="image" src="https://github.com/user-attachments/assets/93b0f4c1-e93a-4870-a932-04f1feb1b41c" />



